### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/src/Icon.php
+++ b/src/Icon.php
@@ -62,6 +62,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
      * As this class implements Countable you can simply use count($icon) if you desire
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->images);
@@ -73,6 +74,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
      * @param integer   $offset
      * @param IconImage $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (!$value instanceof IconImage) {
@@ -91,6 +93,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
      * @param integer $offset
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->images[$offset]);
@@ -102,6 +105,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
      * @param integer $offset
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->images[$offset]);
@@ -113,6 +117,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
      * @param integer $offset
      * @return IconImage
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->images[$offset]) ? $this->images[$offset] : null;
@@ -121,6 +126,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
     /**
      * Implements \Iterator allowing foreach($icon as $image){}
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -129,6 +135,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
     /**
      * Implements \Iterator allowing foreach($icon as $image){}
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->images[$this->position];
@@ -137,6 +144,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
     /**
      * Implements \Iterator allowing foreach($icon as $image){}
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
@@ -145,6 +153,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
     /**
      * Implements \Iterator allowing foreach($icon as $image){}
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
@@ -153,6 +162,7 @@ class Icon implements \ArrayAccess, \Countable, \Iterator
     /**
      * Implements \Iterator allowing foreach($icon as $image){}
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->images[$this->position]);


### PR DESCRIPTION
When I'm using the "from" and "renderImage" functions then I see different errors. One of that errors you can see below:
```
Deprecated function: Return type of Elphin\IcoFileLoader\Icon::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 8 of /var/www/html/vendor/lordelph/icofileloader/src/Icon.php)

#0 /var/www/html/core/includes/bootstrap.inc(347): _drupal_error_handler_real()
#1 /var/www/html/vendor/lordelph/icofileloader/src/Icon.php(8): _drupal_error_handler()
#2 /var/www/html/vendor/composer/ClassLoader.php(571): include('...')
#3 /var/www/html/vendor/composer/ClassLoader.php(428): Composer\Autoload\includeFile()
#4 /var/www/html/vendor/lordelph/icofileloader/src/IcoParser.php(69): Composer\Autoload\ClassLoader->loadClass()
#5 /var/www/html/vendor/lordelph/icofileloader/src/IcoParser.php(55): Elphin\IcoFileLoader\IcoParser->parseICO()
#6 /var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php(126): Elphin\IcoFileLoader\IcoParser->parse()
#7 /var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php(111): Elphin\IcoFileLoader\IcoFileService->fromFile()
```