### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/GdRenderer.php
+++ b/src/GdRenderer.php
@@ -9,7 +9,7 @@ namespace Elphin\IcoFileLoader;
  */
 class GdRenderer implements RendererInterface
 {
-    public function render(IconImage $img, array $opts = null)
+    public function render(IconImage $img, ?array $opts = null)
     {
         $opts = $this->initOptions($img, $opts);
 

--- a/src/IcoFileService.php
+++ b/src/IcoFileService.php
@@ -27,7 +27,7 @@ class IcoFileService
      * @param RendererInterface|null $renderer
      * @param ParserInterface|null $parser
      */
-    public function __construct(RendererInterface $renderer = null, ParserInterface $parser = null)
+    public function __construct(?RendererInterface $renderer = null, ?ParserInterface $parser = null)
     {
         $this->parser = $parser ?: new IcoParser();
         $this->renderer = $renderer ?: new GdRenderer();
@@ -56,7 +56,7 @@ class IcoFileService
      * @throws \DomainException if icon does not contain any images.
      * @throws \InvalidArgumentException if file is not found or is invalid.
      */
-    public function extractIcon($dataOrFile, $w, $h, array $opts = null)
+    public function extractIcon($dataOrFile, $w, $h, ?array $opts = null)
     {
         $icon = $this->from($dataOrFile);
         $image = $icon->findBestForSize($w, $h);
@@ -85,7 +85,7 @@ class IcoFileService
      *                            the result is whatever that renderer returns.
      * @throws \InvalidArgumentException if IconImage or options are invalid.
      */
-    public function renderImage(IconImage $image, $w = null, $h = null, array $opts = null)
+    public function renderImage(IconImage $image, $w = null, $h = null, ?array $opts = null)
     {
         $opts = is_array($opts) ? $opts : [];
         $opts['w'] = $w;

--- a/src/RendererInterface.php
+++ b/src/RendererInterface.php
@@ -15,5 +15,5 @@ interface RendererInterface
      * @param array|null $opts array of name/value pairs specific to the renderer
      * @return mixed|null rendered result, depending on renderer
      */
-    public function render(IconImage $img, array $opts = null);
+    public function render(IconImage $img, ?array $opts = null);
 }


### PR DESCRIPTION
When I use functions `from` and `renderImage`, I encounter the following errors:

1. > **Deprecated**: Elphin\IcoFileLoader\IcoFileService::__construct(): Implicitly marking parameter $renderer as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php** on line **30**

2. > **Deprecated**: Elphin\IcoFileLoader\IcoFileService::__construct(): Implicitly marking parameter $parser as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php** on line **30**

3. > **Deprecated**: Elphin\IcoFileLoader\IcoFileService::extractIcon(): Implicitly marking parameter $opts as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php** on line **59**

4. > **Deprecated**: Elphin\IcoFileLoader\IcoFileService::renderImage(): Implicitly marking parameter $opts as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/IcoFileService.php** on line **88**

5. > **Deprecated**: Elphin\IcoFileLoader\GdRenderer::render(): Implicitly marking parameter $opts as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/GdRenderer.php** on line **12**

6. > **Deprecated**: Elphin\IcoFileLoader\RendererInterface::render(): Implicitly marking parameter $opts as nullable is deprecated, the explicit nullable type must be used instead in **/var/www/html/vendor/lordelph/icofileloader/src/RendererInterface.php** on line **18**